### PR TITLE
[hotfix] ajout dateArrivee dans la request lors de la soumission d'un rapport

### DIFF
--- a/assets/js/pam/components/EquipageComponent.vue
+++ b/assets/js/pam/components/EquipageComponent.vue
@@ -101,6 +101,7 @@ export default {
         membre.agent.prenom = this.tmpAgent.fullName.split(' ')[0];
         membre.observations = this.tmpAgent.observations;
         membre.role = this.tmpAgent.role;
+        membre.agent.dateArrivee = new Date();
         this.tmpAgent = {};
       }
       this.membres.push(membre);

--- a/src/Entity/Agent.php
+++ b/src/Entity/Agent.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\AgentRepository")
@@ -16,11 +17,13 @@ class Agent {
     private $id;
 
     /**
+     * @Groups({"view", "draft", "save_rapport"})
      * @ORM\Column(type="string", length=45)
      */
     private $nom;
 
     /**
+     * @Groups({"view", "draft", "save_rapport"})
      * @ORM\Column(type="string", length=45)
      */
     private $prenom;
@@ -32,6 +35,7 @@ class Agent {
     private $service;
 
     /**
+     * @Groups({"view", "draft", "save_rapport"})
      * @ORM\Column(type="date_immutable")
      */
     private $dateArrivee;


### PR DESCRIPTION
⚠ **Hotfix** : J'ai ajouté le champs `dateArrivee` dans le body de le request. Elle a comme valeur la date courante.

Le rapporteur doit il ajouter manuellement la date d'arrivée des nouveaux arrivant ? Ou cela peut il être précisé après (en dehors de la rédaction du rapport) ?